### PR TITLE
Реализация опции --lang

### DIFF
--- a/OllamaCommitGen.Cli/Binders/CommitGenBinder.cs
+++ b/OllamaCommitGen.Cli/Binders/CommitGenBinder.cs
@@ -1,12 +1,14 @@
 using System.CommandLine;
 using System.CommandLine.Binding;
+using Iso639;
 using OllamaCommitGen.Domain.Interfaces;
 using OllamaCommitGen.Domain.Services;
 using OllamaCommitGen.Infrastructure.Services;
 
 namespace OllamaCommitGen.Cli.Binders;
 
-public class CommitGenBinder(Option<string> originOption, Option<string> modelOption) : BinderBase<ICommitGenService>
+public class CommitGenBinder(Option<string> originOption, Option<string> modelOption, Option<string> langOption)
+    : BinderBase<ICommitGenService>
 {
     protected override ICommitGenService GetBoundValue(BindingContext bindingContext)
     {
@@ -14,10 +16,16 @@ public class CommitGenBinder(Option<string> originOption, Option<string> modelOp
 
         var uri = bindingContext.ParseResult.GetValueForOption(originOption)!;
         var model = bindingContext.ParseResult.GetValueForOption(modelOption)!;
-        
+        var langStr = bindingContext.ParseResult.GetValueForOption(langOption)!;
+        var lang = Language.FromPart3(langStr);
+
+        if (lang == null) throw new ArgumentException("Provided lang is not an ISO-639-3 valid code");
+
         var ollama = new OllamaService(new HttpClient(), uri);
 
         ollama.RequestBody.Model = model;
+        ollama.RequestBody.System +=
+            $"The language of your response must correspond this ISO-639-3 code: {lang.Part3}.";
 
         return new CommitGenService(git, ollama);
     }

--- a/OllamaCommitGen.Cli/OllamaCommitGen.Cli.csproj
+++ b/OllamaCommitGen.Cli/OllamaCommitGen.Cli.csproj
@@ -13,6 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Iso639" Version="1.0.0" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 

--- a/OllamaCommitGen.Cli/Program.cs
+++ b/OllamaCommitGen.Cli/Program.cs
@@ -36,6 +36,14 @@ class Program
             arity: ArgumentArity.ZeroOrOne,
             defaultValue: false
         );
+
+        var langOption = rootCommand.AddOption<string>(
+            name: "--lang",
+            description: "Specifies a language (ISO-639-3) to be used for generating commit message",
+            alias: "-l",
+            arity: ArgumentArity.ExactlyOne,
+            defaultValue: "eng"
+        );
         
         rootCommand.SetHandler(async (commitGenService, noPrompt) =>
         {
@@ -54,7 +62,7 @@ class Program
             }
             
             commitGenService.Dispose();
-        }, new CommitGenBinder(originOption, modelOption), noPromptOption);
+        }, new CommitGenBinder(originOption, modelOption, langOption), noPromptOption);
 
         var commandLineBuilder = new CommandLineBuilder(rootCommand);
         


### PR DESCRIPTION
TL;DR: реализовал опцию `--lang` для выбора языка генерации сообщения для коммита. Для выбора языка используется стандарт *ISO-639-3*.

---

Для валидации заданного языка используется стандарт *ISO-639-3*. Для этого добавил NuGet пакет **Iso639**.

С помощью библиотеки ***System.CommandLine*** добавил строковую опцию `--lang` со значением по умолчанию "eng". Эта опция передается в `CommitGenBinder` (т.к. напрямую влияет на поведение соответствующего сервиса), где к системному сообщению для Ollama добавляется указание языка, который необходимо использовать.

Если предоставленное значение `--lang` не соответствует какому-либо коду *ISO-639-3*, то выбрасывается исключение `ArgumentException`.

Примечание: на любом языке, кроме английского, Ollama генерирует не совсем "хорошие" сообщения. Если использовать английский язык, то все прекрасно.