### PR TITLE
Фикс: ConsoleWrapper не работает с многострочным текстом

### DIFF
--- a/OllamaCommitGen.Cli/Utils/ConsoleWrapper.cs
+++ b/OllamaCommitGen.Cli/Utils/ConsoleWrapper.cs
@@ -7,67 +7,129 @@ public static class ConsoleWrapper
     public static string WriteEditableLine(string text)
     {
         Console.Write("\x1B[5 q");
-        var initialPosition = Console.GetCursorPosition().Left;
+        var initPos = Console.GetCursorPosition();
         Console.Write(text);
         var sb = new StringBuilder(text);
-        var cursorPosition = text.Length + initialPosition;
+        var sbPos = Console.GetCursorPosition();
         ConsoleKeyInfo keyInfo;
 
         while ((keyInfo = Console.ReadKey(true)).Key != ConsoleKey.Enter)
+        {
+            var pos = Console.GetCursorPosition();
+
             switch (keyInfo.Key)
             {
-                case ConsoleKey.LeftArrow when cursorPosition > initialPosition:
-                    Console.SetCursorPosition(--cursorPosition, Console.CursorTop);
+                case ConsoleKey.LeftArrow when pos.Left > initPos.Left || pos.Top > initPos.Top:
+                    if (pos.Top > initPos.Top)
+                    {
+                        if (pos.Left - 1 >= 0)
+                            Console.SetCursorPosition(pos.Left - 1, pos.Top);
+                        else
+                            Console.SetCursorPosition(Console.BufferWidth - 1, pos.Top - 1);
+                    }
+                    else
+                    {
+                        Console.SetCursorPosition(pos.Left - 1, pos.Top);
+                    }
+
                     break;
-                case ConsoleKey.RightArrow when cursorPosition < sb.Length + initialPosition:
-                    Console.SetCursorPosition(++cursorPosition, Console.CursorTop);
+                case ConsoleKey.RightArrow when pos.Left < sbPos.Left || pos.Top < sbPos.Top:
+                    if (pos.Top < sbPos.Top)
+                    {
+                        if (pos.Left + 1 < Console.BufferWidth)
+                            Console.SetCursorPosition(pos.Left + 1, pos.Top);
+                        else
+                            Console.SetCursorPosition(0, pos.Top + 1);
+                    }
+                    else
+                    {
+                        Console.SetCursorPosition(pos.Left + 1, pos.Top);
+                    }
+                    
                     break;
                 case ConsoleKey.Home:
-                    cursorPosition = initialPosition;
-                    Console.SetCursorPosition(cursorPosition, Console.CursorTop);
+                    Console.SetCursorPosition(initPos.Left, initPos.Top);
                     break;
                 case ConsoleKey.End:
-                    cursorPosition = sb.Length + initialPosition;
-                    Console.SetCursorPosition(cursorPosition, Console.CursorTop);
+                    Console.SetCursorPosition(sbPos.Left, sbPos.Top);
                     break;
-                case ConsoleKey.Backspace when cursorPosition > initialPosition:
-                    sb = sb.Remove(cursorPosition - initialPosition - 1, 1);
-                    ClearFromTo(initialPosition, initialPosition + sb.Length + 1);
+                case ConsoleKey.Backspace when pos.Left > initPos.Left || pos.Top > initPos.Top:
+                    sb = sb.Remove((pos.Top - initPos.Top) * Console.BufferWidth - initPos.Left + pos.Left - 1, 1);
+                    ClearFromTo(initPos, sbPos);
                     Console.Write(sb.ToString());
-                    Console.SetCursorPosition(--cursorPosition, Console.CursorTop);
+                    sbPos = Console.GetCursorPosition();
+
+                    if (pos.Top > initPos.Top)
+                    {
+                        if (pos.Left - 1 >= 0)
+                            Console.SetCursorPosition(pos.Left - 1, pos.Top);
+                        else
+                            Console.SetCursorPosition(Console.BufferWidth - 1, pos.Top - 1);
+                    }
+                    else
+                    {
+                        Console.SetCursorPosition(pos.Left - 1, pos.Top);
+                    }
+
                     break;
-                case ConsoleKey.Delete when cursorPosition != sb.Length + initialPosition:
-                    sb = sb.Remove(cursorPosition - initialPosition, 1);
-                    ClearFromTo(initialPosition, initialPosition + sb.Length + 1);
+                case ConsoleKey.Delete when pos.Left != sbPos.Left || pos.Top != sbPos.Top:
+                    sb = sb.Remove((pos.Top - initPos.Top) * Console.BufferWidth - initPos.Left + pos.Left, 1);
+                    ClearFromTo(initPos, sbPos);
                     Console.Write(sb.ToString());
-                    Console.SetCursorPosition(cursorPosition, Console.CursorTop);
+                    sbPos = Console.GetCursorPosition();
+                    Console.SetCursorPosition(pos.Left, pos.Top);
                     break;
                 default:
-                    if (char.IsLetterOrDigit(keyInfo.KeyChar) || keyInfo.Key == ConsoleKey.Spacebar)
+                    if (char.IsLetterOrDigit(keyInfo.KeyChar) || char.IsPunctuation(keyInfo.KeyChar) ||
+                        keyInfo.Key == ConsoleKey.Spacebar)
                     {
-                        sb = sb.Insert(cursorPosition - initialPosition, keyInfo.KeyChar);
-                        ClearFromTo(initialPosition, initialPosition + sb.Length - 1);
+                        sb = sb.Insert((pos.Top - initPos.Top) * Console.BufferWidth - initPos.Left + pos.Left, keyInfo.KeyChar);
+                        ClearFromTo(initPos, sbPos);
                         Console.Write(sb.ToString());
-                        Console.SetCursorPosition(++cursorPosition, Console.CursorTop);
+                        sbPos = Console.GetCursorPosition();
+                        if (pos.Top < sbPos.Top)
+                        {
+                            if (pos.Left + 1 < Console.BufferWidth)
+                                Console.SetCursorPosition(pos.Left + 1, pos.Top);
+                            else
+                                Console.SetCursorPosition(0, pos.Top + 1);
+                        }
+                        else if (pos.Left < sbPos.Left)
+                        {
+                            Console.SetCursorPosition(pos.Left + 1, pos.Top);
+                        }
                     }
+
                     break;
             }
+        }
 
+        Console.SetCursorPosition(sbPos.Left, sbPos.Top);
         Console.Write("\x1B[0 q");
         Console.Write(Environment.NewLine);
 
         return sb.ToString();
     }
 
-    private static void ClearFromTo(int from, int to)
+    private static void ClearFromTo((int left, int top) pos1, (int left, int top) pos2)
     {
-        Console.SetCursorPosition(to, Console.CursorTop);
-        
-        while (to != from)
-        {
-            Console.Write("\b \b");
-            --to;
-            Console.SetCursorPosition(to, Console.CursorTop);
-        }
+        Console.SetCursorPosition(pos2.left, pos2.top);
+
+        while (pos1.left != pos2.left || pos1.top != pos2.top)
+            if (pos2.left == 0 && pos2.top > pos1.top)
+            {
+                pos2.left = Console.BufferWidth - 1;
+                pos2.top -= 1;
+                Console.SetCursorPosition(pos2.left, pos2.top);
+                Console.Write(" ");
+                Console.SetCursorPosition(pos2.left, pos2.top);
+            }
+            else
+            {
+                Console.Write("\b \b");
+                Console.SetCursorPosition(--pos2.left, pos2.top);
+            }
+
+        Console.SetCursorPosition(pos1.left, pos1.top);
     }
 }


### PR DESCRIPTION
TL;DR: `ConsoleWrapper` не работал с многострочным текстом. Так, если Ollama выдавал сообщение для коммита, которое не умещалось на одну строчку терминала, то при попытке изменения этого сообщения вылетало исключение. Баг исправлен.

---

Теперь `ConsoleWrapper` переписан так, чтобы работать с многострочным текстом. Теперь нет никаких проблем, если сообщение для коммита вышло не несколько строк терминала: все переносы курсора, добавление или удаление символов работают исправно.

Также к разрешенным символам в сообщение коммита добавлены пунктуационные знаки.

Оставшаяся проблема: если после запуска приложения изменить размер окна терминала, то при попытке изменить сообщение для коммита снова вылетит исключение. Связано это с тем, что при изменении размера окна терминала, также изменяются и размер буфера консоли и положение курсора, что никак не отслеживается в приложении, т.к. отсутствуют какие-либо события типа `Console.BufferSizeChanged`.

Если после запуска приложения не менять размер окна консоли, то все будет работать штатно.