### PR TITLE
Реализация опции --keepalive

### DIFF
--- a/OllamaCommitGen.Cli/Binders/CommitGenBinder.cs
+++ b/OllamaCommitGen.Cli/Binders/CommitGenBinder.cs
@@ -7,7 +7,11 @@ using OllamaCommitGen.Infrastructure.Services;
 
 namespace OllamaCommitGen.Cli.Binders;
 
-public class CommitGenBinder(Option<string> originOption, Option<string> modelOption, Option<string> langOption)
+public class CommitGenBinder(
+    Option<string> originOption,
+    Option<string> modelOption,
+    Option<string> langOption,
+    Option<string> keepaliveOption)
     : BinderBase<ICommitGenService>
 {
     protected override ICommitGenService GetBoundValue(BindingContext bindingContext)
@@ -18,6 +22,7 @@ public class CommitGenBinder(Option<string> originOption, Option<string> modelOp
         var model = bindingContext.ParseResult.GetValueForOption(modelOption)!;
         var langStr = bindingContext.ParseResult.GetValueForOption(langOption)!;
         var lang = Language.FromPart3(langStr);
+        var keepalive = bindingContext.ParseResult.GetValueForOption(keepaliveOption)!;
 
         if (lang == null) throw new ArgumentException("Provided lang is not an ISO-639-3 valid code");
 
@@ -26,6 +31,7 @@ public class CommitGenBinder(Option<string> originOption, Option<string> modelOp
         ollama.RequestBody.Model = model;
         ollama.RequestBody.System +=
             $"The language of your response must correspond this ISO-639-3 code: {lang.Part3}.";
+        ollama.RequestBody.KeepAlive = keepalive;
 
         return new CommitGenService(git, ollama);
     }

--- a/OllamaCommitGen.Cli/Program.cs
+++ b/OllamaCommitGen.Cli/Program.cs
@@ -44,6 +44,14 @@ class Program
             arity: ArgumentArity.ExactlyOne,
             defaultValue: "eng"
         );
+
+        var keepaliveOption = rootCommand.AddOption<string>(
+            name: "--keepalive",
+            description: "Specifies how long the model will stay loaded into memory following the request",
+            alias: "-k",
+            arity: ArgumentArity.ExactlyOne,
+            defaultValue: "5m"
+        );
         
         rootCommand.SetHandler(async (commitGenService, noPrompt) =>
         {
@@ -62,7 +70,7 @@ class Program
             }
             
             commitGenService.Dispose();
-        }, new CommitGenBinder(originOption, modelOption, langOption), noPromptOption);
+        }, new CommitGenBinder(originOption, modelOption, langOption, keepaliveOption), noPromptOption);
 
         var commandLineBuilder = new CommandLineBuilder(rootCommand);
         

--- a/OllamaCommitGen.Infrastructure/DataObjects/OllamaRequestBody.cs
+++ b/OllamaCommitGen.Infrastructure/DataObjects/OllamaRequestBody.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace OllamaCommitGen.Infrastructure.DataObjects;
 
 public class OllamaRequestBody
@@ -10,4 +12,7 @@ public class OllamaRequestBody
         "You are to act as the author of a commit message in git. Your mission is to create clean and comprehensive commit messages and explain WHAT were the changes and mainly WHY the changes were done. I'll send you an output of 'git diff --staged' command, and you are to convert it into a commit message. Use the present tense. Lines must not be longer than 74 characters. Your response must consist of only message for the commit.";
     
     public bool Stream { get; set; } = false;
+
+    [JsonPropertyName("keep_alive")]
+    public string KeepAlive { get; set; } = "5m";
 }


### PR DESCRIPTION
TL;DR: реализовал опцию `--keepalive` для контроля времени загруженности модели в памяти. Реализовано так же, как и опции `--model`, `--lang`.

---

С помощью библиотеки ***System.CommandLine*** добавил новую опцию `--keepalive`, у которой alias "-k", принимает только один аргумент и значение по умолчанию "5m", что соответствует 5 минутам.

Далее пробросил эту опцию в `CommitGenBinder`, т.к. она непосредственно влияет на сервис `ICommitGenService`. Значение этой опции присваивается новому свойству тела запроса - KeepAlive, которое при сериализации будет иметь имя "keep_alive", т.к. именно такой формат нужен для Ollama REST API.