### PR TITLE
Реализация конфигурации через файл

### DIFF
--- a/OllamaCommitGen.Cli/Binders/CommitGenBinder.cs
+++ b/OllamaCommitGen.Cli/Binders/CommitGenBinder.cs
@@ -1,7 +1,7 @@
 using System.CommandLine.Binding;
 using Iso639;
 using OllamaCommitGen.Cli.Models;
-using OllamaCommitGen.Domain.Interfaces;
+using OllamaCommitGen.Domain.Abstractions;
 using OllamaCommitGen.Domain.Services;
 using OllamaCommitGen.Infrastructure.Services;
 using OllamaSharp.Models;

--- a/OllamaCommitGen.Cli/Binders/CommitGenBinder.cs
+++ b/OllamaCommitGen.Cli/Binders/CommitGenBinder.cs
@@ -1,6 +1,8 @@
+using System.CommandLine;
 using System.CommandLine.Binding;
 using Iso639;
 using OllamaCommitGen.Cli.Models;
+using OllamaCommitGen.Cli.Utils;
 using OllamaCommitGen.Domain.Abstractions;
 using OllamaCommitGen.Domain.Services;
 using OllamaCommitGen.Infrastructure.Services;
@@ -14,13 +16,17 @@ public class CommitGenBinder(PrimaryOptions primaryOptions, ModelOptions modelOp
     {
         var git = new GitService(Directory.GetCurrentDirectory());
 
-        var uri = bindingContext.ParseResult.GetValueForOption(primaryOptions.OriginOption)!;
-        var model = bindingContext.ParseResult.GetValueForOption(primaryOptions.ModelOption)!;
-        var langStr = bindingContext.ParseResult.GetValueForOption(primaryOptions.LangOption)!;
-        var lang = Language.FromPart3(langStr);
-        var keepalive = bindingContext.ParseResult.GetValueForOption(primaryOptions.KeepAliveOption)!;
-        var noStream = bindingContext.ParseResult.GetValueForOption(primaryOptions.NoStreamOption)!;
+        var configPath = bindingContext.ParseResult.GetValueForOption(primaryOptions.ConfigOption);
+        AppConfig? appConfig = null;
+        if (configPath != null) appConfig = ConfigLoader.LoadAppConfig(configPath);
 
+        var uri = ResolveOptionValue(bindingContext, primaryOptions.OriginOption, appConfig?.Origin);
+        var model = ResolveOptionValue(bindingContext, primaryOptions.ModelOption, appConfig?.Model);
+        var langStr = ResolveOptionValue(bindingContext, primaryOptions.LangOption, appConfig?.Lang);
+        var keepalive = ResolveOptionValue(bindingContext, primaryOptions.KeepAliveOption, appConfig?.KeepAlive);
+        var noStream = ResolveOptionValue(bindingContext, primaryOptions.NoStreamOption, appConfig?.NoStream);
+
+        var lang = Language.FromPart3(langStr);
         if (lang == null) throw new ArgumentException("Provided lang is not an ISO-639-3 valid code");
 
         var ollama = new OllamaService(uri);
@@ -31,19 +37,21 @@ public class CommitGenBinder(PrimaryOptions primaryOptions, ModelOptions modelOp
         ollama.Request.KeepAlive = keepalive;
         ollama.Request.Stream = !noStream;
 
-        var miroStat = bindingContext.ParseResult.GetValueForOption(modelOptions.MiroStatOption)!;
-        var miroStatEta = bindingContext.ParseResult.GetValueForOption(modelOptions.MiroStatEtaOption)!;
-        var miroStatTau = bindingContext.ParseResult.GetValueForOption(modelOptions.MiroStatTauOption)!;
-        var numCtx = bindingContext.ParseResult.GetValueForOption(modelOptions.NumCtxOption)!;
-        var repeatLastN = bindingContext.ParseResult.GetValueForOption(modelOptions.RepeatLastNOption)!;
-        var repeatPenalty = bindingContext.ParseResult.GetValueForOption(modelOptions.RepeatPenaltyOption)!;
-        var temperature = bindingContext.ParseResult.GetValueForOption(modelOptions.TemperatureOption)!;
-        var seed = bindingContext.ParseResult.GetValueForOption(modelOptions.SeedOption)!;
-        var stop = bindingContext.ParseResult.GetValueForOption(modelOptions.StopOption);
-        var tfsZ = bindingContext.ParseResult.GetValueForOption(modelOptions.TfsZOption)!;
-        var numPredict = bindingContext.ParseResult.GetValueForOption(modelOptions.NumPredictOption)!;
-        var topK = bindingContext.ParseResult.GetValueForOption(modelOptions.TopKOption)!;
-        var topP = bindingContext.ParseResult.GetValueForOption(modelOptions.TopPOption)!;
+        var miroStat = ResolveOptionValue(bindingContext, modelOptions.MiroStatOption, appConfig?.MiroStat);
+        var miroStatEta = ResolveOptionValue(bindingContext, modelOptions.MiroStatEtaOption, appConfig?.MiroStatEta);
+        var miroStatTau = ResolveOptionValue(bindingContext, modelOptions.MiroStatTauOption, appConfig?.MiroStatTau);
+        var numCtx = ResolveOptionValue(bindingContext, modelOptions.NumCtxOption, appConfig?.NumCtx);
+        var repeatLastN = ResolveOptionValue(bindingContext, modelOptions.RepeatLastNOption, appConfig?.RepeatLastN);
+        var repeatPenalty = ResolveOptionValue(bindingContext, modelOptions.RepeatPenaltyOption, appConfig?.RepeatPenalty);
+        var temperature = ResolveOptionValue(bindingContext, modelOptions.TemperatureOption, appConfig?.Temperature);
+        var seed = ResolveOptionValue(bindingContext, modelOptions.SeedOption, appConfig?.Seed);
+#pragma warning disable CS8634 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'class' constraint.
+        var stop = ResolveOptionValue(bindingContext, modelOptions.StopOption, appConfig?.Stop);
+#pragma warning restore CS8634
+        var tfsZ = ResolveOptionValue(bindingContext, modelOptions.TfsZOption, appConfig?.TfsZ);
+        var numPredict = ResolveOptionValue(bindingContext, modelOptions.NumPredictOption, appConfig?.NumPredict);
+        var topK = ResolveOptionValue(bindingContext, modelOptions.TopKOption, appConfig?.TopK);
+        var topP = ResolveOptionValue(bindingContext, modelOptions.TopPOption, appConfig?.TopP);
 
         ollama.Request.Options = new RequestOptions()
         {
@@ -63,5 +71,31 @@ public class CommitGenBinder(PrimaryOptions primaryOptions, ModelOptions modelOp
         };
 
         return new CommitGenService(git, ollama);
+    }
+
+    private T ResolveOptionValue<T>(BindingContext ctx, Option<T> opt, T? configVal) where T : struct
+    {
+        var optResult = ctx.ParseResult.FindResultFor(opt);
+        var optValue = ctx.ParseResult.GetValueForOption(opt)!;
+
+        if (optResult != null && !optResult.IsImplicit)
+            return optValue;
+        if (configVal.HasValue)
+            return configVal.Value;
+
+        return optValue;
+    }
+
+    private T ResolveOptionValue<T>(BindingContext ctx, Option<T> opt, T? configVal) where T : class
+    {
+        var optResult = ctx.ParseResult.FindResultFor(opt);
+        var optValue = ctx.ParseResult.GetValueForOption(opt)!;
+
+        if (optResult != null && !optResult.IsImplicit)
+            return optValue;
+        if (configVal != null)
+            return configVal;
+
+        return optValue;
     }
 }

--- a/OllamaCommitGen.Cli/Extensions/CommandExtensions.cs
+++ b/OllamaCommitGen.Cli/Extensions/CommandExtensions.cs
@@ -38,7 +38,7 @@ public static class CommandExtensions
             description: "Specifies an Ollama model to be used",
             alias: "-m",
             arity: ArgumentArity.ExactlyOne,
-            defaultValue: "llama3"
+            defaultValue: "codellama"
         );
 
         var langOption = command.AddOption<string>(
@@ -65,13 +65,22 @@ public static class CommandExtensions
             defaultValue: false
         );
 
+        var configOption = command.AddOption<string>(
+            name: "--config",
+            description: "Specifies configuration file. JSON format is supported",
+            alias: "-c",
+            arity: ArgumentArity.ExactlyOne,
+            defaultValue: null
+        );
+
         return new PrimaryOptions()
         {
             OriginOption = originOption,
             ModelOption = modelOption,
             LangOption = langOption,
             KeepAliveOption = keepaliveOption,
-            NoStreamOption = noStreamOption
+            NoStreamOption = noStreamOption,
+            ConfigOption = configOption
         };
     }
 

--- a/OllamaCommitGen.Cli/Models/AppConfig.cs
+++ b/OllamaCommitGen.Cli/Models/AppConfig.cs
@@ -1,0 +1,41 @@
+﻿namespace OllamaCommitGen.Cli.Models
+{
+    public class AppConfig
+    {
+        public string? Origin { get; set; } = null!;
+
+        public string? Model { get; set; } = null!;
+
+        public string? Lang { get; set; } = null!;
+
+        public string? KeepAlive { get; set; } = null!;
+
+        public bool? NoStream { get; set; }
+
+        public int? MiroStat { get; set; }
+
+        public float? MiroStatEta { get; set; }
+
+        public float? MiroStatTau { get; set; }
+
+        public int? NumCtx { get; set; }
+
+        public int? RepeatLastN { get; set; }
+
+        public float? RepeatPenalty { get; set; }
+
+        public float? Temperature { get; set; }
+
+        public int? Seed { get; set; }
+
+        public string[]? Stop { get; set; }
+
+        public float? TfsZ { get; set; }
+
+        public int? NumPredict { get; set; }
+
+        public int? TopK { get; set; }
+
+        public float? TopP { get; set; }
+    }
+}

--- a/OllamaCommitGen.Cli/Models/PrimaryOptions.cs
+++ b/OllamaCommitGen.Cli/Models/PrimaryOptions.cs
@@ -13,4 +13,6 @@ public class PrimaryOptions
     public Option<string> KeepAliveOption { get; set; }
     
     public Option<bool> NoStreamOption { get; set; }
+
+    public Option<string> ConfigOption { get; set; }
 }

--- a/OllamaCommitGen.Cli/Utils/ConfigLoader.cs
+++ b/OllamaCommitGen.Cli/Utils/ConfigLoader.cs
@@ -1,0 +1,29 @@
+﻿using OllamaCommitGen.Cli.Models;
+using System.Text.Json;
+
+namespace OllamaCommitGen.Cli.Utils
+{
+    public static class ConfigLoader
+    {
+        public static AppConfig LoadAppConfig(string path)
+        {
+            if (!File.Exists(path)) throw new FileNotFoundException($"Configuration file '{path}' does not exist");
+            var extension = Path.GetExtension(path).ToLowerInvariant();
+
+            return extension switch
+            {
+                ".json" => LoadJsonConfig(path),
+                _ => throw new NotSupportedException($"Unsupported config format: {extension}")
+            };
+        }
+
+        private static AppConfig LoadJsonConfig(string path)
+        {
+            var json = File.ReadAllText(path);
+            var config = JsonSerializer.Deserialize<AppConfig>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                ?? throw new InvalidOperationException("Failed to parse JSON configuration");
+
+            return config;
+        }
+    }
+}

--- a/OllamaCommitGen.Domain/Abstractions/ICommitGenService.cs
+++ b/OllamaCommitGen.Domain/Abstractions/ICommitGenService.cs
@@ -1,6 +1,6 @@
 using OllamaSharp.Models;
 
-namespace OllamaCommitGen.Domain.Interfaces;
+namespace OllamaCommitGen.Domain.Abstractions;
 
 public interface ICommitGenService : IDisposable
 {

--- a/OllamaCommitGen.Domain/Abstractions/IGitService.cs
+++ b/OllamaCommitGen.Domain/Abstractions/IGitService.cs
@@ -1,6 +1,6 @@
 using LibGit2Sharp;
 
-namespace OllamaCommitGen.Domain.Interfaces;
+namespace OllamaCommitGen.Domain.Abstractions;
 
 public interface IGitService : IDisposable
 {

--- a/OllamaCommitGen.Domain/Abstractions/IOllamaService.cs
+++ b/OllamaCommitGen.Domain/Abstractions/IOllamaService.cs
@@ -1,6 +1,6 @@
 using OllamaSharp.Models;
 
-namespace OllamaCommitGen.Domain.Interfaces;
+namespace OllamaCommitGen.Domain.Abstractions;
 
 public interface IOllamaService
 {

--- a/OllamaCommitGen.Domain/Services/CommitGenService.cs
+++ b/OllamaCommitGen.Domain/Services/CommitGenService.cs
@@ -1,4 +1,4 @@
-using OllamaCommitGen.Domain.Interfaces;
+using OllamaCommitGen.Domain.Abstractions;
 using OllamaSharp.Models;
 
 namespace OllamaCommitGen.Domain.Services;

--- a/OllamaCommitGen.Infrastructure/Services/GitService.cs
+++ b/OllamaCommitGen.Infrastructure/Services/GitService.cs
@@ -1,6 +1,6 @@
 using System.Text;
 using LibGit2Sharp;
-using OllamaCommitGen.Domain.Interfaces;
+using OllamaCommitGen.Domain.Abstractions;
 
 namespace OllamaCommitGen.Infrastructure.Services;
 

--- a/OllamaCommitGen.Infrastructure/Services/OllamaService.cs
+++ b/OllamaCommitGen.Infrastructure/Services/OllamaService.cs
@@ -1,5 +1,5 @@
 using System.Text;
-using OllamaCommitGen.Domain.Interfaces;
+using OllamaCommitGen.Domain.Abstractions;
 using OllamaSharp;
 using OllamaSharp.Models;
 


### PR DESCRIPTION
TL;DR: реализовал конфигурацию инструмента через JSON файлы. Модель ***codellama*** теперь является моделью по умолчанию (вместо модели ***llama3***).

---

Реализовал опцию `--config` (alias `-c`), с помощью которой можно указать глобальный путь до конфигурационного файла JSON.

Для конфигурации через JSON файл доступны все опции, кроме `--no-prompt`. Эта опция задается исключительно через CLI.

Пример полного файла конфигурации:
```JSON
{
	"origin": "http://localhost:11434",
	"model": "codellama",
	"lang": "eng",
	"keepAlive": "5m",
	"noStream": false,
	"miroStat": 0,
	"miroStatEta": 0.1,
	"miroStatTau": 5.0,
	"numCtx": 2048,
	"repeatLastN": 64,
	"repeatPenalty": 1.1,
	"temperature": 0.8,
	"seed": 0,
	"stop": ["data", "file", "code"],
	"tfsZ": 1.0,
	"numPredict": 128,
	"topK": 40,
	"topP": 0.9
}
```

Любая из опций может отсутствовать в файле конфигурации. Тогда будет использовано либо значение, переданное пользователем в CLI, либо значение по умолчанию. Регистр не имеет значения.

Значения для опций берутся из источников с наибольшим приоритетом. Источники конфигурации имеют следующие приоритеты:
 1. Аргументы CLI (наивысший)
 2. Данные из конфигурационного файла (средний)
 3. Значения по умолчанию (низший)

В будущем планируется поддержка форматов ***YAML*** и ***TOML***.