### PR TITLE
Реализация опций --example и --example-description

### DIFF
--- a/OllamaCommitGen.Cli/Extensions/CommandExtensions.cs
+++ b/OllamaCommitGen.Cli/Extensions/CommandExtensions.cs
@@ -73,6 +73,22 @@ public static class CommandExtensions
             defaultValue: null
         );
 
+        var exampleOption = command.AddOption<string>(
+            name: "--example",
+            description: "Specifies an example commit message that the model will look at",
+            alias: "-e",
+            arity: ArgumentArity.ExactlyOne,
+            defaultValue: null
+        );
+
+        var exampleDescriptionOption = command.AddOption<string>(
+            name: "--example-description",
+            description: "Provides explanations for the example commit message so that the model can better understand what is required of it",
+            alias: "-d",
+            arity: ArgumentArity.ExactlyOne,
+            defaultValue: null
+        );
+
         return new PrimaryOptions()
         {
             OriginOption = originOption,
@@ -80,7 +96,9 @@ public static class CommandExtensions
             LangOption = langOption,
             KeepAliveOption = keepaliveOption,
             NoStreamOption = noStreamOption,
-            ConfigOption = configOption
+            ConfigOption = configOption,
+            ExampleOption = exampleOption,
+            ExampleDescriptionOption = exampleDescriptionOption
         };
     }
 

--- a/OllamaCommitGen.Cli/Models/AppConfig.cs
+++ b/OllamaCommitGen.Cli/Models/AppConfig.cs
@@ -12,6 +12,10 @@
 
         public bool? NoStream { get; set; }
 
+        public string? Example { get; set; }
+
+        public string? ExampleDescription { get; set; }
+
         public int? MiroStat { get; set; }
 
         public float? MiroStatEta { get; set; }

--- a/OllamaCommitGen.Cli/Models/PrimaryOptions.cs
+++ b/OllamaCommitGen.Cli/Models/PrimaryOptions.cs
@@ -15,4 +15,8 @@ public class PrimaryOptions
     public Option<bool> NoStreamOption { get; set; }
 
     public Option<string> ConfigOption { get; set; }
+
+    public Option<string> ExampleOption { get; set; }
+
+    public Option<string> ExampleDescriptionOption { get; set; }
 }


### PR DESCRIPTION
TL;DR: реализовал опции `--example` и `--example-description`, чтобы каждый конкретный пользователь имел возможность персонализировать вывод модели под себя.

---

Опция `--example` используется для указания эталонного сообщения для коммита, на которое модель будет ориентироваться при генерации. Опция не имеет значения по умолчанию, однако ее можно задать в файле конфигурации.

Опция `--example-description` используется для указания пользовательских пояснений для эталонного сообщения для коммита. В этих пояснениях пользователь может подробно объяснить что именно он ожидает от модели. При этом нельзя использовать эту опцию в отрыве от опции `--example`. Однако опцию `--example` можно использовать без опции `--example-description`, но не рекомендуется. Опция так же не имеет значения по умолчанию, но ее можно указать в файле конфигурации.

Совокупность этих опций позволяет персонализировать ответы модели под каждого конкретного человека. Достигается это путем добавления соответствующих строк в системное сообщение модели.